### PR TITLE
Register Set Pass

### DIFF
--- a/plans/RegisterSetPass.md
+++ b/plans/RegisterSetPass.md
@@ -1,0 +1,130 @@
+# Register + Set Password Email Flow
+
+## 1. Backend: new REST endpoint
+
+**File:** [brennans-wave-wp/public/api/auth.php](brennans-wave-wp/public/api/auth.php)
+
+- **New route:** `POST brennan/v1/register-with-set-pass-email`
+  - **Permission:** `__return_true` (public).
+  - **Body:** `firstName`, `lastName`, `email` (all required). Optional: `set_password_base_url` (string) so the email link points to the Next.js app (e.g. `https://brennanswave.com`).
+- **Handler** (e.g. `brennan_api_register_with_set_pass_email`):
+  1. Validate/sanitize `firstName`, `lastName`, `email`.
+  2. If `email_exists($email)`, return `{ success: false, error: 'Email already exists.' }` (400).
+  3. Create user with `wp_insert_user`:
+    - `user_login` => email
+    - `user_pass` => `wp_generate_password()` (random placeholder)
+    - `user_email`, `first_name`, `last_name`, `role` => subscriber
+  4. Reuse the same token + email logic as `brennan_api_generate_set_password_token`:
+    - Generate token with `brennan_create_rand_str(64)`, store in `brennan_set_password_token` and `brennan_set_password_token_expires` (5 days).
+    - Build link: base URL = `$body['set_password_base_url']` if set (trimmed), else `home_url('/')`; path = `/set-pass` (to match frontend route). Final URL: `rtrim($base_url, '/') . '/set-pass?token=' . urlencode(base64_encode($token . '|' . $user_id))`.
+    - Load `emails/default.html`, replace `{email_subject}`, `{$user_name}`, `{$set_password_url}`, `{$current_year}`, send via `wp_mail`.
+  5. On success return `{ success: true, message: '...' }`. Do **not** return a login token (user must set password first).
+
+**Optional:** Extract a shared helper (e.g. `brennan_send_set_password_email( $user_id, $base_url_for_link )`) used by both `brennan_api_generate_set_password_token` and the new handler to avoid duplication. The existing admin endpoint can keep using `home_url()` and path `/set-password` unless you want to unify later.
+
+---
+
+## 2. Frontend: auth API helper
+
+**File:** [brennanswave/src/lib/auth-api.ts](brennanswave/src/lib/auth-api.ts)
+
+- Add:
+  - `**registerWithSetPassEmail(firstName: string, lastName: string, email: string, setPasswordBaseUrl?: string)`**
+  - POST to `{apiBase}/wp-json/brennan/v1/register-with-set-pass-email` with body `{ firstName, lastName, email, set_password_base_url?: setPasswordBaseUrl }`.
+  - Return type: `{ success: true; message: string } | { success: false; error: string }`.
+  - Use same `getApiBase()` as existing; for `setPasswordBaseUrl` the caller can pass `typeof window !== 'undefined' ? window.location.origin : ''` so the email link matches the current app origin.
+
+---
+
+## 3. Frontend: RegisterForm component
+
+**File:** [brennanswave/src/components/auth/RegisterForm.tsx](brennanswave/src/components/auth/RegisterForm.tsx) (new)
+
+- **UI (shadcn):** `Label`, `Input`, `Button` from existing UI components.
+- **Fields:**
+  - First Name (text)
+  - Last Name (text)
+  - Email Address (type="email")
+  - Below the fields, small text: “Password set link will be emailed to you.”
+  - Submit button: blue background, white text (e.g. `className="bg-blue-600 text-white hover:bg-blue-700"` or use a primary variant if your theme already has blue).
+- **Behavior:**
+  - Controlled state for firstName, lastName, email; loading and error state.
+  - On submit: call `registerWithSetPassEmail(firstName, lastName, email, window.location.origin)`.
+  - On success: show a success message (e.g. “Check your email for the password setup link.”) and optionally clear form or disable submit.
+  - On error: show API `error` message.
+- **Props:** Can accept optional `onSuccess?: () => void` and/or `successMessage?: ReactNode` for reuse in a dialog vs page.
+
+**File:** [brennanswave/src/components/auth/Register.tsx](brennanswave/src/components/auth/Register.tsx)
+
+- Export the form or a thin wrapper (e.g. render `RegisterForm` inside a card or dialog) so the app can use either a full-page register or a dialog. Minimal change: have `Register.tsx` export `RegisterForm` from `RegisterForm.tsx` for convenience, or render the form in a simple card layout here.
+
+---
+
+## 4. Frontend: Set Password page
+
+**File:** [brennanswave/src/app/set-pass/page.tsx](brennanswave/src/app/set-pass/page.tsx)
+
+- **Route:** `/set-pass?token=...` (token from email link).
+- **Layout:** Use existing `Header` and `Footer`; center content in main.
+- **Logic (client component):**
+  1. Read `token` from URL: `useSearchParams().get('token')`.
+  2. If no token: show message “Invalid or expired link” (and optional link back to login/register).
+  3. If token present: show a “Set password” form:
+    - New password (type="password")
+    - Confirm password (optional but recommended)
+    - Submit button
+  4. On submit: POST to existing `brennan/v1/set-password` with body `{ token: tokenFromUrl, password }`. Use the **raw** `token` query param (the backend expects the same base64 string that was in the link).
+  5. On success: backend returns `{ success, user, token }`; call `setAuth(result.token, result.user)` and redirect (e.g. `router.push('/report')`) or show “Password set” and a link to go home.
+  6. On error: show API error (e.g. “Invalid or expired token”).
+- **Auth API:** Add in [auth-api.ts](brennanswave/src/lib/auth-api.ts):
+  - `**setPasswordWithToken(token: string, password: string)`** – POST to `brennan/v1/set-password` with `{ token, password }`, return typed success/error (success includes `user` and `token` for immediate login).
+
+---
+
+## 5. Data flow summary
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant RegisterForm
+  participant Backend
+  participant Email
+  participant SetPassPage
+
+  User->>RegisterForm: Submit first/last/email
+  RegisterForm->>Backend: POST register-with-set-pass-email
+  Backend->>Backend: Create user, create token
+  Backend->>Email: Send set-password email with /set-pass?token=...
+  Backend->>RegisterForm: success
+  RegisterForm->>User: "Check your email"
+
+  User->>Email: Clicks link
+  Email->>SetPassPage: /set-pass?token=...
+  User->>SetPassPage: Enter new password, submit
+  SetPassPage->>Backend: POST set-password { token, password }
+  Backend->>SetPassPage: { user, token }
+  SetPassPage->>SetPassPage: setAuth(), redirect
+```
+
+
+
+---
+
+## 6. Files to add or touch
+
+
+| Location                                                              | Action                                                                                                                                                                         |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [auth.php](brennans-wave-wp/public/api/auth.php)                      | Register route `register-with-set-pass-email`; add handler (create user with random pass, then send set-password email with `/set-pass` path and optional base URL from body). |
+| [auth-api.ts](brennanswave/src/lib/auth-api.ts)                       | Add `registerWithSetPassEmail()`, add `setPasswordWithToken()`.                                                                                                                |
+| [RegisterForm.tsx](brennanswave/src/components/auth/RegisterForm.tsx) | New: form with first name, last name, email, small text, blue submit; call register API.                                                                                       |
+| [Register.tsx](brennanswave/src/components/auth/Register.tsx)         | Export or render RegisterForm (e.g. in a card).                                                                                                                                |
+| [set-pass/page.tsx](brennanswave/src/app/set-pass/page.tsx)           | New: read `token` from query; form for new (+ confirm) password; call setPasswordWithToken; on success setAuth and redirect.                                                   |
+
+
+---
+
+## 7. Set-password link URL
+
+- Backend will use path `**/set-pass**` in the email link so it matches the Next app route.
+- If the Next app is on a different origin than WordPress, the frontend should send `set_password_base_url` (e.g. `window.location.origin`) in the register request so the link points to the correct domain. If same origin, you can omit it and rely on `home_url()`.

--- a/src/app/set-pass/page.tsx
+++ b/src/app/set-pass/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { setPasswordWithToken, setAuth } from "@/lib/auth-api";
+
+function SetPassForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!token) {
+    return (
+      <div className="w-full max-w-md rounded-lg border bg-white p-6 shadow-sm text-center">
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">
+          Invalid or expired link
+        </h1>
+        <p className="text-sm text-gray-600 mb-4">
+          This set-password link is missing or no longer valid. Request a new one
+          from the register page.
+        </p>
+        <Button asChild variant="outline">
+          <Link href="/login">Go to Log in</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const tokenValue = token;
+    if (!tokenValue) return;
+    setError(null);
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+    if (password.length < 1) {
+      setError("Please enter a password.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await setPasswordWithToken(tokenValue, password);
+      if (result.success) {
+        setAuth(result.token, result.user);
+        router.push("/report");
+      } else {
+        setError(result.error);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md rounded-lg border bg-white p-6 shadow-sm">
+      <h1 className="text-xl font-semibold text-gray-900 mb-1">Set your password</h1>
+      <p className="text-sm text-gray-600 mb-6">
+        Enter a new password for your account.
+      </p>
+      <form onSubmit={handleSubmit} className="grid gap-4">
+        {error && (
+          <p className="text-sm text-destructive bg-destructive/10 rounded-md px-3 py-2">
+            {error}
+          </p>
+        )}
+        <div className="grid gap-2">
+          <Label htmlFor="set-pass-password">New password</Label>
+          <Input
+            id="set-pass-password"
+            type="password"
+            placeholder="••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="new-password"
+            disabled={loading}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="set-pass-confirm">Confirm password</Label>
+          <Input
+            id="set-pass-confirm"
+            type="password"
+            placeholder="••••••••"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            autoComplete="new-password"
+            disabled={loading}
+          />
+        </div>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? "Setting password…" : "Set password"}
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export default function SetPassPage() {
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-12">
+        <Suspense
+          fallback={
+            <div className="w-full max-w-md rounded-lg border bg-white p-6 shadow-sm text-center text-gray-500">
+              Loading…
+            </div>
+          }
+        >
+          <SetPassForm />
+        </Suspense>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/components/auth/Register.tsx
+++ b/src/components/auth/Register.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { RegisterForm } from "@/components/auth/RegisterForm";
+
+export { RegisterForm };
+
+export function Register() {
+  return (
+    <div className="w-full max-w-md rounded-lg border bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-semibold text-gray-900 mb-1">Create an account</h2>
+      <p className="text-sm text-gray-600 mb-6">
+        We&apos;ll send you a link to set your password.
+      </p>
+      <RegisterForm />
+    </div>
+  );
+}

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { registerWithSetPassEmail } from "@/lib/auth-api";
+
+export interface RegisterFormProps {
+  onSuccess?: () => void;
+  successMessage?: React.ReactNode;
+}
+
+export function RegisterForm({ onSuccess, successMessage }: RegisterFormProps) {
+  const [firstName, setFirstName] = React.useState("");
+  const [lastName, setLastName] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const baseUrl =
+        typeof window !== "undefined" ? window.location.origin : undefined;
+      const result = await registerWithSetPassEmail(
+        firstName.trim(),
+        lastName.trim(),
+        email.trim(),
+        baseUrl
+      );
+      if (result.success) {
+        setSuccess(true);
+        setFirstName("");
+        setLastName("");
+        setEmail("");
+        onSuccess?.();
+      } else {
+        setError(result.error);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="rounded-md bg-green-50 dark:bg-green-950/30 p-4 text-sm text-green-800 dark:text-green-200">
+        {successMessage ?? "Check your email for the password setup link."}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-4">
+      {error && (
+        <p className="text-sm text-destructive bg-destructive/10 rounded-md px-3 py-2">
+          {error}
+        </p>
+      )}
+      <div className="grid gap-2">
+        <Label htmlFor="register-first-name">First Name</Label>
+        <Input
+          id="register-first-name"
+          type="text"
+          placeholder="First name"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          required
+          autoComplete="given-name"
+          disabled={loading}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="register-last-name">Last Name</Label>
+        <Input
+          id="register-last-name"
+          type="text"
+          placeholder="Last name"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          required
+          autoComplete="family-name"
+          disabled={loading}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="register-email">Email Address</Label>
+        <Input
+          id="register-email"
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          disabled={loading}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Password set link will be emailed to you.
+      </p>
+      <Button
+        type="submit"
+        className="w-full bg-blue-600 text-white hover:bg-blue-700"
+        disabled={loading}
+      >
+        {loading ? "Submitting…" : "Submit"}
+      </Button>
+    </form>
+  );
+}

--- a/src/lib/auth-api.ts
+++ b/src/lib/auth-api.ts
@@ -25,6 +25,76 @@ export type LoginResponse =
   | { success: true; user: AuthUser; token: string; application_password: string }
   | { success: false; error: string };
 
+export type RegisterWithSetPassEmailResponse =
+  | { success: true; message: string }
+  | { success: false; error: string };
+
+export type SetPasswordResponse =
+  | { success: true; message: string; user: AuthUser; token: string }
+  | { success: false; error: string };
+
+export async function registerWithSetPassEmail(
+  firstName: string,
+  lastName: string,
+  email: string,
+  setPasswordBaseUrl?: string
+): Promise<RegisterWithSetPassEmailResponse> {
+  const base = getApiBase().replace(/\/$/, "");
+  const url = `${base}/wp-json/brennan/v1/register-with-set-pass-email`;
+  const body: { firstName: string; lastName: string; email: string; set_password_base_url?: string } = {
+    firstName,
+    lastName,
+    email,
+  };
+  if (setPasswordBaseUrl) body.set_password_base_url = setPasswordBaseUrl;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json()) as RegisterWithSetPassEmailResponse & { success?: boolean };
+  if (!res.ok) {
+    return {
+      success: false,
+      error: (data as { error?: string }).error ?? "Registration failed.",
+    };
+  }
+  if (data.success && "message" in data) {
+    return data as Extract<RegisterWithSetPassEmailResponse, { success: true }>;
+  }
+  return {
+    success: false,
+    error: (data as { error?: string }).error ?? "Invalid response.",
+  };
+}
+
+export async function setPasswordWithToken(
+  token: string,
+  password: string
+): Promise<SetPasswordResponse> {
+  const base = getApiBase().replace(/\/$/, "");
+  const url = `${base}/wp-json/brennan/v1/set-password`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, password }),
+  });
+  const data = (await res.json()) as SetPasswordResponse & { success?: boolean };
+  if (!res.ok) {
+    return {
+      success: false,
+      error: (data as { error?: string }).error ?? "Failed to set password.",
+    };
+  }
+  if (data.success && "user" in data && "token" in data) {
+    return data as Extract<SetPasswordResponse, { success: true }>;
+  }
+  return {
+    success: false,
+    error: (data as { error?: string }).error ?? "Invalid response.",
+  };
+}
+
 export async function login(login: string, password: string): Promise<LoginResponse> {
   const base = getApiBase().replace(/\/$/, "");
   const url = `${base}/wp-json/brennan/v1/login`;


### PR DESCRIPTION
# Register + Set Password Email Flow

## 1. Backend: new REST endpoint

**File:** [brennans-wave-wp/public/api/auth.php](brennans-wave-wp/public/api/auth.php)

- **New route:** `POST brennan/v1/register-with-set-pass-email`
  - **Permission:** `__return_true` (public).
  - **Body:** `firstName`, `lastName`, `email` (all required). Optional: `set_password_base_url` (string) so the email link points to the Next.js app (e.g. `https://brennanswave.com`).
- **Handler** (e.g. `brennan_api_register_with_set_pass_email`):
  1. Validate/sanitize `firstName`, `lastName`, `email`.
  2. If `email_exists($email)`, return `{ success: false, error: 'Email already exists.' }` (400).
  3. Create user with `wp_insert_user`:
    - `user_login` => email
    - `user_pass` => `wp_generate_password()` (random placeholder)
    - `user_email`, `first_name`, `last_name`, `role` => subscriber
  4. Reuse the same token + email logic as `brennan_api_generate_set_password_token`:
    - Generate token with `brennan_create_rand_str(64)`, store in `brennan_set_password_token` and `brennan_set_password_token_expires` (5 days).
    - Build link: base URL = `$body['set_password_base_url']` if set (trimmed), else `home_url('/')`; path = `/set-pass` (to match frontend route). Final URL: `rtrim($base_url, '/') . '/set-pass?token=' . urlencode(base64_encode($token . '|' . $user_id))`.
    - Load `emails/default.html`, replace `{email_subject}`, `{$user_name}`, `{$set_password_url}`, `{$current_year}`, send via `wp_mail`.
  5. On success return `{ success: true, message: '...' }`. Do **not** return a login token (user must set password first).

**Optional:** Extract a shared helper (e.g. `brennan_send_set_password_email( $user_id, $base_url_for_link )`) used by both `brennan_api_generate_set_password_token` and the new handler to avoid duplication. The existing admin endpoint can keep using `home_url()` and path `/set-password` unless you want to unify later.

---

## 2. Frontend: auth API helper

**File:** [brennanswave/src/lib/auth-api.ts](brennanswave/src/lib/auth-api.ts)

- Add:
  - `**registerWithSetPassEmail(firstName: string, lastName: string, email: string, setPasswordBaseUrl?: string)`**
  - POST to `{apiBase}/wp-json/brennan/v1/register-with-set-pass-email` with body `{ firstName, lastName, email, set_password_base_url?: setPasswordBaseUrl }`.
  - Return type: `{ success: true; message: string } | { success: false; error: string }`.
  - Use same `getApiBase()` as existing; for `setPasswordBaseUrl` the caller can pass `typeof window !== 'undefined' ? window.location.origin : ''` so the email link matches the current app origin.

---

## 3. Frontend: RegisterForm component

**File:** [brennanswave/src/components/auth/RegisterForm.tsx](brennanswave/src/components/auth/RegisterForm.tsx) (new)

- **UI (shadcn):** `Label`, `Input`, `Button` from existing UI components.
- **Fields:**
  - First Name (text)
  - Last Name (text)
  - Email Address (type="email")
  - Below the fields, small text: “Password set link will be emailed to you.”
  - Submit button: blue background, white text (e.g. `className="bg-blue-600 text-white hover:bg-blue-700"` or use a primary variant if your theme already has blue).
- **Behavior:**
  - Controlled state for firstName, lastName, email; loading and error state.
  - On submit: call `registerWithSetPassEmail(firstName, lastName, email, window.location.origin)`.
  - On success: show a success message (e.g. “Check your email for the password setup link.”) and optionally clear form or disable submit.
  - On error: show API `error` message.
- **Props:** Can accept optional `onSuccess?: () => void` and/or `successMessage?: ReactNode` for reuse in a dialog vs page.

**File:** [brennanswave/src/components/auth/Register.tsx](brennanswave/src/components/auth/Register.tsx)

- Export the form or a thin wrapper (e.g. render `RegisterForm` inside a card or dialog) so the app can use either a full-page register or a dialog. Minimal change: have `Register.tsx` export `RegisterForm` from `RegisterForm.tsx` for convenience, or render the form in a simple card layout here.

---

## 4. Frontend: Set Password page

**File:** [brennanswave/src/app/set-pass/page.tsx](brennanswave/src/app/set-pass/page.tsx)

- **Route:** `/set-pass?token=...` (token from email link).
- **Layout:** Use existing `Header` and `Footer`; center content in main.
- **Logic (client component):**
  1. Read `token` from URL: `useSearchParams().get('token')`.
  2. If no token: show message “Invalid or expired link” (and optional link back to login/register).
  3. If token present: show a “Set password” form:
    - New password (type="password")
    - Confirm password (optional but recommended)
    - Submit button
  4. On submit: POST to existing `brennan/v1/set-password` with body `{ token: tokenFromUrl, password }`. Use the **raw** `token` query param (the backend expects the same base64 string that was in the link).
  5. On success: backend returns `{ success, user, token }`; call `setAuth(result.token, result.user)` and redirect (e.g. `router.push('/report')`) or show “Password set” and a link to go home.
  6. On error: show API error (e.g. “Invalid or expired token”).
- **Auth API:** Add in [auth-api.ts](brennanswave/src/lib/auth-api.ts):
  - `**setPasswordWithToken(token: string, password: string)`** – POST to `brennan/v1/set-password` with `{ token, password }`, return typed success/error (success includes `user` and `token` for immediate login).

---

## 5. Data flow summary

```mermaid
sequenceDiagram
  participant User
  participant RegisterForm
  participant Backend
  participant Email
  participant SetPassPage

  User->>RegisterForm: Submit first/last/email
  RegisterForm->>Backend: POST register-with-set-pass-email
  Backend->>Backend: Create user, create token
  Backend->>Email: Send set-password email with /set-pass?token=...
  Backend->>RegisterForm: success
  RegisterForm->>User: "Check your email"

  User->>Email: Clicks link
  Email->>SetPassPage: /set-pass?token=...
  User->>SetPassPage: Enter new password, submit
  SetPassPage->>Backend: POST set-password { token, password }
  Backend->>SetPassPage: { user, token }
  SetPassPage->>SetPassPage: setAuth(), redirect
```



---

## 6. Files to add or touch


| Location                                                              | Action                                                                                                                                                                         |
| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| [auth.php](brennans-wave-wp/public/api/auth.php)                      | Register route `register-with-set-pass-email`; add handler (create user with random pass, then send set-password email with `/set-pass` path and optional base URL from body). |
| [auth-api.ts](brennanswave/src/lib/auth-api.ts)                       | Add `registerWithSetPassEmail()`, add `setPasswordWithToken()`.                                                                                                                |
| [RegisterForm.tsx](brennanswave/src/components/auth/RegisterForm.tsx) | New: form with first name, last name, email, small text, blue submit; call register API.                                                                                       |
| [Register.tsx](brennanswave/src/components/auth/Register.tsx)         | Export or render RegisterForm (e.g. in a card).                                                                                                                                |
| [set-pass/page.tsx](brennanswave/src/app/set-pass/page.tsx)           | New: read `token` from query; form for new (+ confirm) password; call setPasswordWithToken; on success setAuth and redirect.                                                   |


---

## 7. Set-password link URL

- Backend will use path `**/set-pass**` in the email link so it matches the Next app route.
- If the Next app is on a different origin than WordPress, the frontend should send `set_password_base_url` (e.g. `window.location.origin`) in the register request so the link points to the correct domain. If same origin, you can omit it and rely on `home_url()`.

